### PR TITLE
chore: upgrade twig to namespaced classes

### DIFF
--- a/etc/Render.php
+++ b/etc/Render.php
@@ -4,16 +4,19 @@
 namespace Framework;
 
 use Framework\Interfaces\RenderInterfaces;
+use Twig\Environment;
+use Twig\Extension\DebugExtension;
+use Twig\Loader\FilesystemLoader;
 
 class Render implements RenderInterfaces
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
     /**
-     * @var \Twig_Loader_Filesystem
+     * @var FilesystemLoader
      */
     private $loader;
 
@@ -24,16 +27,16 @@ class Render implements RenderInterfaces
      */
     public function __construct(string $path)
     {
-        $this->loader = new \Twig_Loader_Filesystem($path);
-        $this->twig = new \Twig_Environment($this->loader, array('debug' => true));
-        $this->twig->addExtension(new \Twig_Extension_Debug());
+        $this->loader = new FilesystemLoader($path);
+        $this->twig = new Environment($this->loader, ['debug' => true]);
+        $this->twig->addExtension(new DebugExtension());
     }
 
     /**
      * @param string      $namespace
      * @param null|string $path
      *
-     * @throws \Twig_Error_Loader
+     * @throws \Twig\Error\LoaderError
      */
     public function addPath(string $namespace, ?string $path = null): void
     {
@@ -56,9 +59,9 @@ class Render implements RenderInterfaces
      *
      * @return mixed|string
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function render(string $view, array $params = null, $type = 'html')
     {


### PR DESCRIPTION
## Summary
- refactor Render to use Twig 3 namespaces and DebugExtension

## Testing
- `php -l etc/Render.php`
- `composer install` *(fails: lock file out of date)*
- `composer update` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf61adcc8328816b75dd753e7780