### PR TITLE
Use typed PDOState property in PdoStatement

### DIFF
--- a/src/Pdo/PdoStatement.php
+++ b/src/Pdo/PdoStatement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Pdo;
 
 use PDOStatement as PDOState;
@@ -8,9 +10,9 @@ use App\Pdo\Interfaces\PdoStatementInterface;
 class PdoStatement implements PdoStatementInterface
 {
     /**
-     * @var PdoStatement $statement
+     * @var PDOState $statement
      */
-    private $statement;
+    private PDOState $statement;
 
     /**
      * PdoStatement constructor.


### PR DESCRIPTION
## Summary
- add strict types declaration for PdoStatement
- declare statement property using PDOState type

## Testing
- `php -l src/Pdo/PdoStatement.php`
- `composer install` *(fails: lock file outdated)*

------
https://chatgpt.com/codex/tasks/task_e_6891c4ce69288328a34370ba2b5763b5