### PR TITLE
refactor: add return type for home controller

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -12,28 +12,11 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class HomeController
 {
-    /**
-     * @var Articles
-     */
-    private $articles;
-
-    /**
-     * HomeController constructor.
-     *
-     * @param Articles $articles
-     */
-    public function __construct(Articles $articles)
+    public function __construct(private Articles $articles)
     {
-        $this->articles = $articles;
     }
 
     /**
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
-     * @param Container              $container
-     *
-     * @return ResponseInterface
-     *
      * @throws \DI\DependencyException
      * @throws \DI\NotFoundException
      */
@@ -41,13 +24,14 @@ class HomeController
         ServerRequestInterface $request,
         ResponseInterface $response,
         Container $container
-    ) {
+    ): ResponseInterface {
         $articles = $this->articles->home();
         $view = $container->get(RenderInterfaces::class)->render(
             'home',
             ['articles' => $articles]
         );
         $response->getBody()->write($view);
+
         return $response;
     }
 }


### PR DESCRIPTION
## Summary
- type the `HomeController` articles property
- return a `ResponseInterface` from `HomeController::__invoke`
- drop redundant docblocks
- promote `Articles` dependency via PHP 8 constructor property promotion

## Testing
- `composer install` (fails: Required package versions in composer.lock do not satisfy constraints)
- `php -l src/Controller/HomeController.php`


------
https://chatgpt.com/codex/tasks/task_e_6892108697d48328819c6631b9218b33